### PR TITLE
Remove obsolete version attribute from docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,3 @@
-version: "3.9"
 services:
   api:
     container_name: "flask_api"


### PR DESCRIPTION
## Description
This PR removes the `version` attribute from the docker-compose.yml file as it is no longer necessary in recent versions of Docker Compose.

## Motivation
When running `docker compose` with the version attribute present, the following warning is displayed:

> the attribute `version` is obsolete, it will be ignored, please remove it to avoid potential confusion

Removing this attribute eliminates the warning and aligns the configuration with current Docker Compose best practices.

## Changes
- Removed `version` field from docker-compose.yml