### PR TITLE
refactor/docker/setup-multistage-build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,18 @@
-FROM python:3.14.3-trixie
-ADD mre /usr/local/mre
-WORKDIR /usr/local/mre
+FROM python:3.14.3-trixie AS python
+
+
+FROM python AS python_with_libreoffice
+
 RUN apt-get update && \
     apt-get --no-install-recommends install libreoffice -y && \
-    apt-get install -y libreoffice-java-common default-jre && \
-    pip install -r requirements.txt
+    apt-get install -y libreoffice-java-common default-jre
+
+
+FROM python_with_libreoffice AS python_with_libreoffice_and_project_dependencies
+
+COPY mre/requirements.txt ./mre/requirements.txt
+RUN pip install -r ./mre/requirements.txt
+
+FROM python_with_libreoffice_and_project_dependencies AS python_with_libreoffice_and_project_dependencies_and_project_files
+
+COPY mre/server.py ./server.py


### PR DESCRIPTION
Now if a file in the mre folder or a dependency changes, LibreOffice won’t need to be reinstalled in the container.