### PR TITLE
feat/docker/enable-demo-client-to-run-from-the-container

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,4 @@
 #Repository-specific
-output.pdf
 mre/*.pdf
 mre/*.doc
 mre/*.docx

--- a/README.md
+++ b/README.md
@@ -35,8 +35,8 @@ docker compose up
 
 3.1. (UI) Go to [http://localhost:5000/doc_to_pdf](http://localhost:5000/doc_to_pdf), select a local DOC or DOCX file, such as the one in ./mre/dummy_doc.docx, then press `upload` and see whether a PDF file is either displayed on the browser or downloaded automatically.
 
-3.2. (API) Send a dummy DOC or DOCX file to it via a POST request and see whether a file named "output.pdf" has been created in the project's root directory:
+3.2. (API) Send a dummy DOC or DOCX file to it via a POST request and see whether a file named "output.pdf" has been created in the project's mre directory:
 
 ```
-python client.py
+docker exec -it flask_api python client.py
 ```

--- a/mre/client.py
+++ b/mre/client.py
@@ -1,7 +1,7 @@
 import requests
 
 endpoint = "http://localhost:5000/doc_to_pdf"
-path_to_doc = './mre/dummy_doc.docx'
+path_to_doc = './dummy_doc.docx'
 chunk_size = 2000
 
 r = requests.post(endpoint, files={


### PR DESCRIPTION
This removes the need to have Python installed to test the project in dev mode.